### PR TITLE
Update trait handling to omit *all cases* of special traits from attributes

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "segmentio/analytics.js-integration": "^1.0.0",
-    "harrietgrace/omit": "0.1.0"
+    "ianstormtaylor/to-no-case": "0.1.3",
+    "ndhoule/includes": "^1.0.0",
+    "ndhoule/foldl": "^1.0.3"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,9 @@
  */
 
 var integration = require('analytics.js-integration');
-var omit = require('omit');
+var uncase = require('to-no-case');
+var includes = require('includes');
+var foldl = require('foldl');
 
 /**
  * Expose `Outbound` integration.
@@ -68,22 +70,28 @@ Outbound.prototype.loaded = function() {
  */
 
 Outbound.prototype.identify = function(identify) {
-  var traitsToOmit = [
+  var specialTraits = [
     'id',
-    'userId',
+    'user id',
     'email',
     'phone',
-    'firstName',
-    'lastName'
+    'first name',
+    'last name'
   ];
+
   var userId = identify.userId() || identify.anonymousId();
-  var attributes = {
-    attributes: omit(traitsToOmit, identify.traits()),
+
+  var attributes = foldl(function(acc, val, key) {
+    if (!includes(uncase(key), specialTraits)) acc.attributes[key] = val;
+    return acc;
+  }, {
+    attributes: {},
     email: identify.email(),
     phoneNumber: identify.phone(),
     firstName: identify.firstName(),
     lastName: identify.lastName()
-  };
+  }, identify.traits());
+
   window.outbound.identify(userId, attributes);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,8 @@ describe('Outbound', function() {
           firstName: 'test',
           lastName: 'user',
           phone: '+14155551234',
-          username: 'testUser'
+          username: 'testUser',
+          genericTrait: 'traitValue'
         };
         var attributes = {
           email: 'testing@outbound.io',
@@ -95,7 +96,32 @@ describe('Outbound', function() {
           lastName: 'user',
           phoneNumber: '+14155551234',
           attributes: {
-            username: 'testUser'
+            username: 'testUser',
+            genericTrait: 'traitValue'
+          }
+        };
+
+        analytics.identify('user123', testTraits);
+        analytics.called(window.outbound.identify, 'user123', attributes);
+      });
+
+      it('should send omit top-level traits from attributes', function() {
+        var testTraits = {
+          Email: 'testing@outbound.io',
+          FirstName: 'test',
+          lastName: 'user',
+          phone: '+14155551234',
+          username: 'testUser',
+          genericTrait: 'traitValue'
+        };
+        var attributes = {
+          email: 'testing@outbound.io',
+          firstName: 'test',
+          lastName: 'user',
+          phoneNumber: '+14155551234',
+          attributes: {
+            username: 'testUser',
+            genericTrait: 'traitValue'
           }
         };
 


### PR DESCRIPTION
Previously, the way this integration was written, "top-level" user attributes (email, first name, last name, phone) would be erroneously included twice if sent in anything but camel-case — once in their respective top level parameters and once in the catch-all `attributes` sub-object.

That's redundant, and not how our server-side integration works. This fix eliminates that behavior so that the top-level attributes are excluded from the catch-all `attributes` sub-object.

[The test case I added](https://github.com/segment-integrations/analytics.js-integration-outbound/pull/1/files#diff-0fd0e07cf6d02bf7cf00f18cebb8e6eaR110) will fail, including `attributes.Email` in the `attributes` sub-object, until this fix is made.

@ndhoule 
