### PR TITLE
Stop window.outbound from leaking across test runs

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,7 @@ describe('Outbound', function() {
   afterEach(function() {
     analytics.restore();
     analytics.reset();
+    outbound.reset();
     sandbox();
   });
 
@@ -47,6 +48,7 @@ describe('Outbound', function() {
       });
 
       it('should extend window.outbound with methods', function() {
+        analytics.initialize();
         var methods = [
           'identify',
           'track',


### PR DESCRIPTION
`window.outbound` was leaking across tests, causing unpredictable behavior. This change clears it after each test, and fixes a test that was relying on this leaking behavior.

@f2prateek 
